### PR TITLE
Single namespace testing

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -87,11 +87,13 @@ runs:
         sudo mkdir -p /etc/jumpstarter/exporters
         sudo chown $USER /etc/jumpstarter/exporters
 
+        export JS_NAMESPACE="jumpstarter-lab"
+
         . .venv/bin/activate
 
         export JUMPSTARTER_GRPC_INSECURE=1
 
-        kubectl create -n default sa test-client-sa
-        kubectl create -n default sa test-exporter-sa
+        kubectl create -n "${JS_NAMESPACE}" sa test-client-sa
+        kubectl create -n "${JS_NAMESPACE}" sa test-exporter-sa
 
         bats --show-output-of-passing-tests --verbose-run "$GITHUB_ACTION_PATH"/tests.bats

--- a/tests.bats
+++ b/tests.bats
@@ -1,3 +1,5 @@
+JS_NAMESPACE="${JS_NAMESPACE:-jumpstarter-lab}"
+
 setup() {
   bats_load_library bats-support
   bats_load_library bats-assert
@@ -9,30 +11,30 @@ wait_for_exporter() {
   # After a lease operation the exporter is disconnecting from controller and reconnecting.
   # The disconnect can take a short while so let's avoid catching the pre-disconnect state and early return
   sleep 2
-  kubectl -n default wait --timeout 20m --for=condition=Online --for=condition=Registered \
+  kubectl -n "${JS_NAMESPACE}" wait --timeout 20m --for=condition=Online --for=condition=Registered \
     exporters.jumpstarter.dev/test-exporter-oidc
-  kubectl -n default wait --timeout 20m --for=condition=Online --for=condition=Registered \
+  kubectl -n "${JS_NAMESPACE}" wait --timeout 20m --for=condition=Online --for=condition=Registered \
     exporters.jumpstarter.dev/test-exporter-sa
-  kubectl -n default wait --timeout 20m --for=condition=Online --for=condition=Registered \
+  kubectl -n "${JS_NAMESPACE}" wait --timeout 20m --for=condition=Online --for=condition=Registered \
     exporters.jumpstarter.dev/test-exporter-legacy
 }
 
 @test "can create clients with admin cli" {
-  jmp admin create client   test-client-oidc     --unsafe --out /dev/null \
+  jmp admin create client -n "${JS_NAMESPACE}" test-client-oidc     --unsafe --out /dev/null \
     --oidc-username dex:test-client-oidc
-  jmp admin create client   test-client-sa       --unsafe --out /dev/null \
-    --oidc-username dex:system:serviceaccount:default:test-client-sa
-  jmp admin create client   test-client-legacy   --unsafe --save
+  jmp admin create client -n "${JS_NAMESPACE}" test-client-sa       --unsafe --out /dev/null \
+    --oidc-username dex:system:serviceaccount:"${JS_NAMESPACE}":test-client-sa
+  jmp admin create client -n "${JS_NAMESPACE}" test-client-legacy   --unsafe --save
 }
 
 @test "can create exporters with admin cli" {
-  jmp admin create exporter test-exporter-oidc   --out /dev/null \
+  jmp admin create exporter -n "${JS_NAMESPACE}" test-exporter-oidc   --out /dev/null \
     --oidc-username dex:test-exporter-oidc \
     --label example.com/board=oidc
-  jmp admin create exporter test-exporter-sa     --out /dev/null \
-    --oidc-username dex:system:serviceaccount:default:test-exporter-sa \
+  jmp admin create exporter -n "${JS_NAMESPACE}" test-exporter-sa     --out /dev/null \
+    --oidc-username dex:system:serviceaccount:"${JS_NAMESPACE}":test-exporter-sa \
     --label example.com/board=sa
-  jmp admin create exporter test-exporter-legacy --save \
+  jmp admin create exporter -n "${JS_NAMESPACE}" test-exporter-legacy --save \
     --label example.com/board=legacy
 }
 
@@ -41,31 +43,31 @@ wait_for_exporter() {
   jmp config exporter list
 
   jmp login --client test-client-oidc \
-    --endpoint "$ENDPOINT" --namespace default --name test-client-oidc \
+    --endpoint "$ENDPOINT" --namespace "${JS_NAMESPACE}" --name test-client-oidc \
     --issuer https://dex.dex.svc.cluster.local:5556 \
     --username test-client-oidc@example.com --password password --unsafe
 
   jmp login --client test-client-oidc-provisioning \
-    --endpoint "$ENDPOINT" --namespace default --name "" \
+    --endpoint "$ENDPOINT" --namespace "${JS_NAMESPACE}" --name "" \
     --issuer https://dex.dex.svc.cluster.local:5556 \
     --username test-client-oidc-provisioning@example.com --password password --unsafe
 
   jmp login --client test-client-sa \
-    --endpoint "$ENDPOINT" --namespace default --name test-client-sa \
+    --endpoint "$ENDPOINT" --namespace "${JS_NAMESPACE}" --name test-client-sa \
     --issuer https://dex.dex.svc.cluster.local:5556 \
     --connector-id kubernetes \
-    --token $(kubectl create -n default token test-client-sa) --unsafe
+    --token $(kubectl create -n "${JS_NAMESPACE}" token test-client-sa) --unsafe
 
   jmp login --exporter test-exporter-oidc \
-    --endpoint "$ENDPOINT" --namespace default --name test-exporter-oidc \
+    --endpoint "$ENDPOINT" --namespace "${JS_NAMESPACE}" --name test-exporter-oidc \
     --issuer https://dex.dex.svc.cluster.local:5556 \
     --username test-exporter-oidc@example.com --password password
 
   jmp login --exporter test-exporter-sa \
-    --endpoint "$ENDPOINT" --namespace default --name test-exporter-sa \
+    --endpoint "$ENDPOINT" --namespace "${JS_NAMESPACE}" --name test-exporter-sa \
     --issuer https://dex.dex.svc.cluster.local:5556 \
     --connector-id kubernetes \
-    --token $(kubectl create -n default token test-exporter-sa)
+    --token $(kubectl create -n "${JS_NAMESPACE}" token test-exporter-sa)
 
   go run github.com/mikefarah/yq/v4@latest -i ". * load(\"$GITHUB_ACTION_PATH/exporter.yaml\")" \
     /etc/jumpstarter/exporters/test-exporter-oidc.yaml
@@ -104,10 +106,13 @@ EOF
 @test "can specify client config only using environment variables" {
   wait_for_exporter
 
-  JMP_NAMEPSACE=default \
+  # we feed the namespace into JMP_NAMESPACE along with all the other client details
+  # to verify that the client can operate without a config file
+  JMP_NAMESPACE="${JS_NAMESPACE}" \
+  JMP_DRIVERS_ALLOW="*" \
   JMP_NAME=test-exporter-legacy \
-  JMP_ENDPOINT=$(kubectl get clients.jumpstarter.dev -n default test-client-legacy -o 'jsonpath={.status.endpoint}') \
-  JMP_TOKEN=$(kubectl get secrets -n default test-client-legacy-client -o 'jsonpath={.data.token}' | base64 -d) \
+  JMP_ENDPOINT=$(kubectl get clients.jumpstarter.dev -n "${JS_NAMESPACE}" test-client-legacy -o 'jsonpath={.status.endpoint}') \
+  JMP_TOKEN=$(kubectl get secrets -n "${JS_NAMESPACE}" test-client-legacy-client -o 'jsonpath={.data.token}' | base64 -d) \
   jmp shell --selector example.com/board=oidc j power on
 }
 
@@ -134,39 +139,39 @@ EOF
 }
 
 @test "can get crds with admin cli" {
-  jmp admin get client
-  jmp admin get exporter
-  jmp admin get lease
+  jmp admin get client --namespace "${JS_NAMESPACE}"
+  jmp admin get exporter --namespace "${JS_NAMESPACE}"
+  jmp admin get lease --namespace "${JS_NAMESPACE}"
 }
 
 @test "can delete clients with admin cli" {
-  kubectl -n default get secret test-client-oidc-client
-  kubectl -n default get clients.jumpstarter.dev/test-client-oidc
-  kubectl -n default get clients.jumpstarter.dev/test-client-sa
-  kubectl -n default get clients.jumpstarter.dev/test-client-legacy
+  kubectl -n "${JS_NAMESPACE}" get secret test-client-oidc-client
+  kubectl -n "${JS_NAMESPACE}" get clients.jumpstarter.dev/test-client-oidc
+  kubectl -n "${JS_NAMESPACE}" get clients.jumpstarter.dev/test-client-sa
+  kubectl -n "${JS_NAMESPACE}" get clients.jumpstarter.dev/test-client-legacy
 
-  jmp admin delete client   test-client-oidc   --delete
-  jmp admin delete client   test-client-sa     --delete
-  jmp admin delete client   test-client-legacy --delete
+  jmp admin delete client --namespace "${JS_NAMESPACE}" test-client-oidc   --delete
+  jmp admin delete client --namespace "${JS_NAMESPACE}" test-client-sa     --delete
+  jmp admin delete client --namespace "${JS_NAMESPACE}" test-client-legacy --delete
 
-  run ! kubectl -n default get secret test-client-oidc-client
-  run ! kubectl -n default get clients.jumpstarter.dev/test-client-oidc
-  run ! kubectl -n default get clients.jumpstarter.dev/test-client-sa
-  run ! kubectl -n default get clients.jumpstarter.dev/test-client-legacy
+  run ! kubectl -n "${JS_NAMESPACE}" get secret test-client-oidc-client
+  run ! kubectl -n "${JS_NAMESPACE}" get clients.jumpstarter.dev/test-client-oidc
+  run ! kubectl -n "${JS_NAMESPACE}" get clients.jumpstarter.dev/test-client-sa
+  run ! kubectl -n "${JS_NAMESPACE}" get clients.jumpstarter.dev/test-client-legacy
 }
 
 @test "can delete exporters with admin cli" {
-  kubectl -n default get secret test-exporter-oidc-exporter
-  kubectl -n default get exporters.jumpstarter.dev/test-exporter-oidc
-  kubectl -n default get exporters.jumpstarter.dev/test-exporter-sa
-  kubectl -n default get exporters.jumpstarter.dev/test-exporter-legacy
+  kubectl -n "${JS_NAMESPACE}" get secret test-exporter-oidc-exporter
+  kubectl -n "${JS_NAMESPACE}" get exporters.jumpstarter.dev/test-exporter-oidc
+  kubectl -n "${JS_NAMESPACE}" get exporters.jumpstarter.dev/test-exporter-sa
+  kubectl -n "${JS_NAMESPACE}" get exporters.jumpstarter.dev/test-exporter-legacy
 
-  jmp admin delete exporter test-exporter-oidc   --delete
-  jmp admin delete exporter test-exporter-sa     --delete
-  jmp admin delete exporter test-exporter-legacy --delete
+  jmp admin delete exporter --namespace "${JS_NAMESPACE}" test-exporter-oidc   --delete
+  jmp admin delete exporter --namespace "${JS_NAMESPACE}" test-exporter-sa     --delete
+  jmp admin delete exporter --namespace "${JS_NAMESPACE}" test-exporter-legacy --delete
 
-  run ! kubectl -n default get secret test-exporter-oidc-exporter
-  run ! kubectl -n default get exporters.jumpstarter.dev/test-exporter-oidc
-  run ! kubectl -n default get exporters.jumpstarter.dev/test-exporter-sa
-  run ! kubectl -n default get exporters.jumpstarter.dev/test-exporter-legacy
+  run ! kubectl -n "${JS_NAMESPACE}" get secret test-exporter-oidc-exporter
+  run ! kubectl -n "${JS_NAMESPACE}" get exporters.jumpstarter.dev/test-exporter-oidc
+  run ! kubectl -n "${JS_NAMESPACE}" get exporters.jumpstarter.dev/test-exporter-sa
+  run ! kubectl -n "${JS_NAMESPACE}" get exporters.jumpstarter.dev/test-exporter-legacy
 }


### PR DESCRIPTION
We only want to support single-namespace operator for one controller, so we can isolate multiple controllers with their sets of exporters and clients to individual namespaces in a single cluster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a configurable Kubernetes namespace via a new environment variable, allowing deployments and runtime steps to target a custom namespace.

* **Tests**
  * Updated test suite to default and propagate the configured namespace dynamically across all Kubernetes operations, resource creation, waits, lookups, and login flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->